### PR TITLE
Removed appveyor build section

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,8 +23,3 @@ build_script:
   - cd build
   - cmake -G"%GENERATOR%" ../src
   - cmake --build . --config Release --target check
-
-build:
-  parallel: true
-  verbosity: minimal
-


### PR DESCRIPTION
It seems to cause the error: 
```
The build phase is set to "MSBuild" mode (default), but no Visual Studio project or solution files were found in the root directory. If you are not building Visual Studio project switch build mode to "Script" and provide your custom build command.
```